### PR TITLE
Remove marketing language from documentation

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -67,11 +67,11 @@ condition := dcb.NewAppendCondition(
 err := store.AppendIf(ctx, events, condition)
 ```
 
-**Benefits:**
-- **Fail-fast**: Immediate detection of conflicts
-- **Business rules**: Enforce domain-specific constraints
-- **Performance**: No blocking, no waiting
-- **Scalability**: Works across multiple instances
+**What DCB Provides:**
+- **Conflict Detection**: Identifies when business rules are violated during event appends
+- **Domain Constraints**: Allows you to define conditions that must be met before events can be stored
+- **Non-blocking**: Doesn't wait for locks or other resources
+- **Multi-instance Support**: Can work across different application instances
 
 ## Usage Examples
 

--- a/docs/performance-comparison.md
+++ b/docs/performance-comparison.md
@@ -67,11 +67,11 @@ The web app performance is significantly lower than the Go library due to:
 3. **Conflict Detection**: Fail-fast on concurrent modifications
 4. **Domain Logic**: Enforce business constraints
 
-#### Benefits
-- **Fail-fast**: Immediate conflict detection
-- **Business rules**: Domain-specific validation
-- **Scalability**: Works across multiple instances
-- **Predictable**: Consistent performance characteristics
+#### What DCB Provides
+- **Conflict Detection**: Identifies when business rules are violated during event appends
+- **Domain Constraints**: Allows you to define conditions that must be met before events can be stored
+- **Multi-instance Support**: Can work across different application instances
+- **Consistent Performance**: Predictable behavior under load
 
 #### Trade-offs
 - **Performance**: Slightly slower than simple append
@@ -92,8 +92,8 @@ The web app performance is significantly lower than the Go library due to:
 3. **High-throughput Scenarios**: Bulk data ingestion
 4. **Simple Workflows**: No business rule requirements
 
-#### Benefits
-- **Maximum Performance**: Fastest option available
+#### Characteristics
+- **Higher Performance**: Faster than DCB operations due to no condition checking
 - **Simplicity**: No condition setup required
 - **Low Memory**: Minimal overhead
 - **Reliability**: Consistent performance


### PR DESCRIPTION
- Replace 'Benefits' sections with factual 'What DCB Provides' descriptions
- Change 'Maximum Performance' to 'Higher Performance' with explanation
- Remove marketing buzzwords like 'Fail-fast', 'Scalability', 'Business rules'
- Use more modest and factual language throughout
- Focus on what the code actually does rather than marketing claims